### PR TITLE
Create plugin directory if it doesn't exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ if [ -e $HOME/.vim/plugin/MKD.vim ]; then
 fi
 
 echo "Copying plugin/* to $HOME/.vim/plugin ... "
+mkdir -p $HOME/.vim/plugin
 cp -R plugin/* $HOME/.vim/plugin
 echo "DONE.."
 


### PR DESCRIPTION
If it doesn't exist, install.sh spews out the help text of cp and then confusingly write DONE (even if nothing was copied).
