### PR TITLE
Added support for alternate filename extensions.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -22,6 +22,14 @@ $HOME/.vim/plugin/
 
     sh install.sh
 
+## Configuration
+
+* `g:markdown_extensions` - default: `["md", "mkd", "markdown", "mdwn"]`
+    
+    Sets the filename extensions that will be rendered.
+
+        let g:markdown_extensions=["md", "markdown", "txt"]
+
 ## Usage
 
 Send vim the command `:Mm` for a preview of your markdown document.  

--- a/plugin/markdown-preview.css
+++ b/plugin/markdown-preview.css
@@ -1,44 +1,104 @@
-body div#content {
-  margin            : 0 auto;
-  width             : 920px;
-  background-color  : #f8f8f8;
-  padding           : .7em;
-  font-size         : 13.34px;
-  font-family       : verdana, sans-serif;
-  border            : 1px #E0E0E0 solid;
+body {
+    background-color:#f8f8f8;
+    font-family:Helvetica;
+    color:#000;
+    font-size: 14px;
 }
-
-body div#content h2, body div#content h3, body div#content h4 {
-  padding-top  : 10px;
-  border-top   : 4px solid #E0E0E0;
+h1,h2,h3,h4,h5,h6 {
+    border:0;
 }
-
-body div#content pre {
-  padding          : 5px;
-  border-style     : solid;
-  border-width     : 1px;
-  border-color     : #E0E0E0;
-  background-color : #F8F8FF;
+h1 {
+    font-size: 170%;
+    border-top: 4px solid #aaa;
+    padding-top: .5em;
+    margin-top: 1.5em;
 }
-
-body div#content pre code {
-  padding          : 5px;
-  background-color : #F8F8FF;
-  border           : none;
+h1:first-child { margin-top:0;
+    padding-top:.25em;
+    border-top:none;
 }
-
-body div#content code {
-  font-family      : courier, fixed;
-  display          : inline-block;
-  padding          : 0px 2px 0px 2px;
-  background-color : #F8F8FF;
-  border           : 1px #E0E0E0 solid;
+h2 {
+    font-size:150%;
+    margin-top:1.5em;
+    border-top:4px solid #e0e0e0;
+    padding-top:.5em;
 }
-
-body h4#title {
-  font-family : verdana, sans-serif;
-  display     : block;
-  margin      : 0 auto;
-  width       : 920px;
+h3 {
+    margin-top:1em;
 }
-
+p{
+    margin:1em 0;
+    line-height:1.5em;
+}
+ul, ol {
+    margin:1em 0 1em 0;
+    padding-left: 2em;
+}
+ul li{
+    margin-top:.5em;
+    margin-bottom:.5em;
+}
+ul ul,ul ol,ol ol,ol ul,{
+    margin-top:0;
+    margin-bottom:0;
+    margin-left: 1em;
+}
+blockquote{margin:1em 0;
+    border-left:5px solid #ddd;
+    padding-left:.6em;
+    color:#555;
+}
+dt{
+    font-weight:bold;
+    margin-left:1em;
+}
+dd{
+    margin-left:2em;
+    margin-bottom:1em;
+}
+table{
+    margin:1em 0;
+}
+table th{
+    border-bottom:1px solid #bbb;
+    padding:.2em 1em;
+}
+table td{
+    border-bottom:1px solid #ddd;
+    padding:.2em 1em;
+}
+pre{
+    margin:1em 0;
+    font-size:12px;
+    background-color:#f8f8ff;
+    border:1px solid #dedede;
+    padding:.5em;
+    line-height:1.5em;
+    color:#444;
+    overflow:auto;
+}
+pre code {
+    padding:0;
+    font-size:12px;
+    background-color:#f8f8ff;
+    border:none;
+}
+code {
+    font-size:12px;
+    background-color:#f8f8ff;
+    color:#444;
+    padding:0 .2em;
+    border:1px solid #dedede;
+}
+a { color:#4183c4;
+    text-decoration:none;
+}
+a:hover {
+    text-decoration:underline;
+}
+a code,a:link code,a:visited code {
+    color:#4183c4;
+}
+img {
+    max-width:100%;
+}

--- a/plugin/vmp.vim
+++ b/plugin/vmp.vim
@@ -44,9 +44,14 @@ function! PreviewMKD()
     </html>
     LAYOUT
 
-
-    unless File.extname(name) =~ /\.(md|mdwn|mkd|markdown)/
-      VIM.message('This file extension is not supported for Markdown previews')
+    set_extensions = VIM.evaluate('g:markdown_extensions')
+    if defined? set_extensions
+        extensions_re = set_extensions.join('|')
+    else
+        extensions_re = 'md|mkd|markdown|mdwn'
+    end
+    unless File.extname(name) =~ /\.(#{extensions_re})/
+      VIM.message('This file extension is not supported for Markdown previews. Add it to the g:markdown_extensions list to enable.')
     else
       file = File.join('/tmp', File.basename(name) + '.html')
       File.open('%s' % [ file ], 'w') { |f| f.write(layout) }

--- a/plugin/vmp.vim
+++ b/plugin/vmp.vim
@@ -45,7 +45,7 @@ function! PreviewMKD()
     LAYOUT
 
 
-    unless File.extname(name) =~ /\.(md|mkd|markdown)/
+    unless File.extname(name) =~ /\.(md|mdwn|mkd|markdown)/
       VIM.message('This file extension is not supported for Markdown previews')
     else
       file = File.join('/tmp', File.basename(name) + '.html')


### PR DESCRIPTION
[Ikiwiki](http://ikiwiki.info/) uses .mdwn for markdown files. Also I use a lot of .txt files that are really markdown. Usage is:

```
let g:markdown_extensions=["md", "markdown", "txt"]
```
