### PR TITLE
fixed: Need to redraw Vim window in text mode (terminal)

### DIFF
--- a/plugin/vmp.vim
+++ b/plugin/vmp.vim
@@ -53,6 +53,7 @@ function! PreviewMKD()
       Vim.command("silent !open '%s'" % [ file ])
     end
 RUBY
+:redraw!
 endfunction
 
 :command! Mm :call PreviewMKD()


### PR DESCRIPTION
The Preview web-page breaks the vim window in text mode: need to redraw it every time with Ctrl+L. Add automatic redraw.
